### PR TITLE
Add issue templates for this Wordpress plugin

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,11 @@
+---
+name: Bug report
+about: Did you find a bug? 
+title: 'Bug: '
+labels: Bug
+assignees: ''
+---
+
+# Bug report
+
+Experiencing an issue with this WordPress plugin?

--- a/.github/ISSUE_TEMPLATE/component-01-initial-proposal.md
+++ b/.github/ISSUE_TEMPLATE/component-01-initial-proposal.md
@@ -1,0 +1,45 @@
+---
+name: New Gutenberg Block, Initial proposal
+about: Define a Gutenberg Block
+title: 'Define: Name'
+labels: Gutenberg Block, New proposal
+assignees: ''
+---
+
+Here is a proposal for a Gutenberg block to include in this WordPress plugin.
+
+---
+
+## Checklist
+- [ ] Name
+- [ ] Location in CA Design System
+- [ ] About this block
+- [ ] Description
+- [ ] Examples
+- [ ] Features
+- [ ] Requesting agency
+
+### Name
+*What should we call this component in conversation?*
+
+## Location in CA Design System
+*If this component already exists as a proposal in the CA Design system, link to it here.*
+*If it does not already exist, please add it. This repository should just help create Gutenberg blocks for designs in the Design System.*
+
+Original Issue in @cagov/design-system repo: 
+
+## About this block
+*Please tell us more about the block.*
+
+### Description
+*Describe how this component will be used.*
+
+### Examples
+*(Can be screenshots, a few examples is great. Please include URLs if the examples are live.) This helps everyone understand what you are referring to.*
+
+### Features
+*Critical features to support initially.*
+
+### Requesting agency
+*Who is requesting this component?*
+

--- a/.github/ISSUE_TEMPLATE/component-02-gutenberg-block.md
+++ b/.github/ISSUE_TEMPLATE/component-02-gutenberg-block.md
@@ -1,0 +1,25 @@
+---
+name: Gutenberg Block Development
+about: After a component is scoped out, metadata assigned, this issue template can be used to help track development issues.
+title: 'Development: Name'
+labels: Component, Development
+assignees: ''
+---
+
+# Component development
+
+Development tasks for a design system component.
+
+Component Name: 
+Original Issue, Design System: 
+Original Issue: 
+
+---
+
+## Checklist
+- [ ] Front end experience defined
+- [ ] Editor experience defined
+- [ ] Gutenberg Block Metadata
+- [ ] Data structure
+- [ ] Notes for content editors
+- [ ] Any other Wordpress considerations

--- a/.github/ISSUE_TEMPLATE/improvement.md
+++ b/.github/ISSUE_TEMPLATE/improvement.md
@@ -1,0 +1,11 @@
+---
+name: Improvement
+about: Share a suggestion for improving this plugin
+title: 'Improvement:'
+labels: Improvement
+assignees: ''
+---
+
+# Improvement
+
+Have a suggestion for improving this plugin?


### PR DESCRIPTION
Add issue templates for this Wordpress plugin, including the beginning of a template about defining our Gutenberg Blocks