### PR TITLE
fix expanded svg in safari

### DIFF
--- a/blocks/card/style.css
+++ b/blocks/card/style.css
@@ -32,6 +32,7 @@
   width: 1rem;
   margin-top: .2rem;
   margin-left: 1rem;
+  max-height: 25px;
 }
 
 .cagov-card:hover {


### PR DESCRIPTION
In Safari the svg carets are taking up way too much vertical space, need to constrain them and then card layout isn't stretched