### PR TITLE
1.0.9

### DIFF
--- a/blocks/post-list/web-component.js
+++ b/blocks/post-list/web-component.js
@@ -114,8 +114,6 @@ class CAGovPostList extends window.HTMLElement {
     }
 
     let getExcerpt = this.showExcerpt === "true" ? `<div class="excerpt"><p>${excerpt.rendered}</p></div>` : ``;
-
-    console.log("this.showPublishedDate", this.showPublishedDate);
     let getDate = this.showPublishedDate === "true" ? `<div class="date">${dateFormatted}</div>` : ``;
 
     return `<div class="post-list-item">

--- a/ca-design-system-gutenberg-blocks.php
+++ b/ca-design-system-gutenberg-blocks.php
@@ -5,7 +5,7 @@
  * Description: Gutenberg blocks for CA Design System
  * Author: Office of Digital Innovation
  * Author URI: https://digital.ca.gov
- * Version: 1.0.8
+ * Version: 1.0.9
  * License: MIT
  * License URI: https://opensource.org/licenses/MIT
  * Text Domain: ca-design-system
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // Constants.
-define( 'CA_DESIGN_SYSTEM_GUTENBERG_BLOCKS__VERSION', '1.0.8' );
+define( 'CA_DESIGN_SYSTEM_GUTENBERG_BLOCKS__VERSION', '1.0.9' );
 define( 'CA_DESIGN_SYSTEM_GUTENBERG_BLOCKS__BLOCKS_DIR_PATH', plugin_dir_path( __FILE__ ) );
 define( 'CA_DESIGN_SYSTEM_GUTENBERG_BLOCKS__ADMIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'CA_DESIGN_SYSTEM_GUTENBERG_BLOCKS__FILE', __FILE__ );

--- a/includes/page-resources.php
+++ b/includes/page-resources.php
@@ -21,21 +21,16 @@ add_action('cagov_content_menu', 'cagov_content_menu');
  */
 function cagov_breadcrumb()
 {
-    /* Quick breadcrumb function, @TODO Register in plugin to call as a shortcode or function */
+    /* Quick breadcrumb function */
 
     global $post;
 
     $separator = "<span class=\"crumb separator\">/</span>";
     $linkOff = true;
 
-    // @TODO Iterate through footer menu (or any menus) to locate links.
-    // $supported_menus = array('header-menu', 'footer-menu'); 
-
     $items = wp_get_nav_menu_items('header-menu');
 
     _wp_menu_item_classes_by_context($items); // Set up the class variables, including current-classes
-
-    // @TODO Move default breadcrumbs to plugin settings
 
     $crumbs = array(
         "<a class=\"crumb\" href=\"https:\/\/ca.gov\" title=\"CA.GOV\">CA.GOV</a>",
@@ -60,8 +55,6 @@ function cagov_breadcrumb()
         $crumbs[] = "<span class=\"crumb current\">{$category->name}</span>";
     }
 
-    // @TODO STILL IN PROGRESS If page is a child of a category that's in the menu system, find the parent in the menu tree & add links to breadcrumbs.
-
     // Configuration note: requires that a menu item link to a category page.
     if (count($crumbs) == 2 && !is_category()) {
         $category = get_the_category($post->ID);
@@ -83,8 +76,8 @@ function cagov_breadcrumb()
             $crumbs[] = "<span class=\"crumb current\">" . $category[0]->name . "</span>";
         }
     }
-
-    echo '<div class="breadcrumb">' . implode($separator, $crumbs) . '</div>';
+    
+    echo '<div class="breadcrumb" aria-label="Breadcrumb" role="region">' . implode($separator, $crumbs) . '</div>';
 }
 
 /**

--- a/includes/templates/plugin/category-template.php
+++ b/includes/templates/plugin/category-template.php
@@ -16,20 +16,20 @@ if (file_exists(get_stylesheet_directory() . '/header.php')) {
 }
 ?>
 
-<div id="page-container" class="page-container-ds">
-    
-    <?php
-        do_action("cagov_breadcrumb");
-    ?>
-
+<div id="page-container" class="page-container-default">
     <div id="main-content" class="main-content-ds single-column" tabindex="-1">
-        <div class="section">
+        <?php
+        global $wp_query;
+        $category = get_category(get_query_var('cat'), false);
+        ?>
+        <?php
+        do_action("cagov_breadcrumb");
+        ?>
+        <div class="narrow-page-title">
+            <?php echo $category->name; ?>
+        </div>
+        <div class="ds-content-layout">
             <main class="main-primary">
-                <?php
-                global $wp_query;
-                $category = get_category(get_query_var('cat'), false);
-                ?>
-
                 <h1 class="page-title"><?php echo $category->name; ?></h1>
                 <div class="wp-block-ca-design-system-post-list cagov-post-list cagov-stack">
                     <div>
@@ -40,13 +40,12 @@ if (file_exists(get_stylesheet_directory() . '/header.php')) {
 
                 <span class="return-top hidden-print"></span>
             </main>
-            
-        </div> <!-- #main-content -->
-    </div>
+        </div>
+    </div> <!-- #main-content -->
 </div>
 
 <?php
-    do_action("cagov_content_menu");
+do_action("cagov_content_menu");
 ?>
 
 <?php get_footer(); ?>

--- a/includes/templates/template-page-landing.php
+++ b/includes/templates/template-page-landing.php
@@ -18,7 +18,7 @@ if (file_exists(get_stylesheet_directory() . '/header.php')) {
 <div id="page-container" class="page-container-ds">
 
     <div id="main-content" class="main-content-ds single-column" tabindex="-1">
-        <div>
+        <div class="ds-content-layout">
             <main class="main-primary">
 
                 <?php

--- a/includes/templates/template-page-single-column.php
+++ b/includes/templates/template-page-single-column.php
@@ -16,13 +16,11 @@ if (file_exists(get_stylesheet_directory() . '/header.php')) {
 ?>
 
 <div id="page-container" class="page-container-ds">
-
-    <?php
-        do_action("cagov_breadcrumb");
-    ?>
-
     <div id="main-content" class="main-content-ds single-column" tabindex="-1">
-        <div>
+        <?php
+            do_action("cagov_breadcrumb");
+        ?>
+        <div class="ds-content-layout">
             <main class="main-primary">
 
                 <?php

--- a/includes/templates/template-page.php
+++ b/includes/templates/template-page.php
@@ -16,59 +16,56 @@ if (file_exists(get_stylesheet_directory() . '/header.php')) {
 ?>
 
 <div id="page-container" class="with-sidebar has-sidebar-left page-container-ds">
-
-    <?php
-        do_action("cagov_breadcrumb");
-    ?>
-
     <div id="main-content" class="main-content-ds" tabindex="-1">
-
+        <?php
+            do_action("cagov_breadcrumb");
+        ?>
         <div class="narrow-page-title">
-            <?php
-            if ('on' === get_post_meta($post->ID, 'ca_custom_post_title_display', true)) {
-                esc_html(the_title('<h1 class="page-title">', '</h1>'));
-            }
-            ?>
-        </div>
-
-
-        <div class="sidebar-container everylayout" style="z-index: 1;">
-            <sidebar space="0" side="left">
-                <cagov-content-navigation data-selector="main" data-type="wordpress" data-label="On this page"></cagov-content-navigation>
-            </sidebar>
-        </div>
-
-        <div class="everylayout">
-            <main class="main-primary">
                 <?php
-                while (have_posts()) :
-                    the_post();
+                if ('on' === get_post_meta($post->ID, 'ca_custom_post_title_display', true)) {
+                    esc_html(the_title('<h1 class="page-title">', '</h1>'));
+                }
                 ?>
+        </div>
+        <div class="ds-content-layout">
+            <div class="sidebar-container everylayout" style="z-index: 1;">
+                <sidebar space="0" side="left">
+                    <cagov-content-navigation data-selector="main" data-type="wordpress" data-label="On this page"></cagov-content-navigation>
+                </sidebar>
+            </div>
 
-                    <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
+            <div class="everylayout">
+                <main class="main-primary">
+                    <?php
+                    while (have_posts()) :
+                        the_post();
+                    ?>
 
-                    
-                        <?php
+                        <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
 
-                        if ('on' === get_post_meta($post->ID, 'ca_custom_post_title_display', true)) {
-                            esc_html(the_title('<h1 class="wide-page-title page-title">', '</h1>'));
-                        }
+                        
+                            <?php
+
+                            if ('on' === get_post_meta($post->ID, 'ca_custom_post_title_display', true)) {
+                                esc_html(the_title('<h1 class="wide-page-title page-title">', '</h1>'));
+                            }
 
 
-                        print '<div class="entry-content">';
+                            print '<div class="entry-content">';
 
-                        the_content();
+                            the_content();
 
-                        print '</div>';
+                            print '</div>';
 
-                        ?>
+                            ?>
 
-                    </article> <!-- .et_pb_post -->
+                        </article> <!-- .et_pb_post -->
 
-                <?php endwhile; ?>
-                <span class="return-top hidden-print"></span>
+                    <?php endwhile; ?>
+                    <span class="return-top hidden-print"></span>
 
-            </main>
+                </main>
+            </div>
         </div>
     </div> <!-- #main-content -->
 

--- a/includes/templates/template-single-event.php
+++ b/includes/templates/template-single-event.php
@@ -173,20 +173,24 @@ if (file_exists(get_stylesheet_directory() . '/header.php')) {
 ?>
 
 <div id="page-container" class="page-container-ds">
-
-    <?php
-    do_action("cagov_breadcrumb");
-    ?>
-
     <div id="main-content" class="main-content-ds single-column" tabindex="-1">
-        <div>
+        <?php
+            do_action("cagov_breadcrumb");
+        ?>
+        <div class="ds-content-layout">
             <main class="main-primary">
-                <?php
-                while (have_posts()) :
-                    the_post();
-                ?>
-                    <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
-                        <category-label><?php the_category(); ?></category-label>
+                <div>
+                    <?php
+                    while (have_posts()) :
+                        the_post();
+                    ?>
+
+                    <?php
+                        $category = get_the_category();
+                    ?>
+
+                        <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
+                            <category-label><?php echo $category[0]->cat_name; ?></category-label>
                         <!-- Page Title-->
                         <?php
                         if ('on' === get_post_meta($post->ID, 'ca_custom_post_title_display', true)) {

--- a/includes/templates/template-single-press-release.php
+++ b/includes/templates/template-single-press-release.php
@@ -17,13 +17,11 @@ if (file_exists(get_stylesheet_directory() . '/header.php')) {
 ?>
 
 <div id="page-container" class="page-container-ds">
-
-    <?php
-        do_action("cagov_breadcrumb");
-    ?>
-
     <div id="main-content" class="main-content-ds single-column" tabindex="-1">
-         <div class="everylayout">
+        <?php
+            do_action("cagov_breadcrumb");
+        ?>
+        <div class="ds-content-layout">
             <main class="main-primary">
                 <div>
                     <?php
@@ -31,8 +29,12 @@ if (file_exists(get_stylesheet_directory() . '/header.php')) {
                         the_post();
                     ?>
 
+                    <?php
+                        $category = get_the_category();
+                    ?>
+
                         <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
-                            <category-label><?php the_category(); ?></category-label>
+                            <category-label><?php echo $category[0]->cat_name; ?></category-label>
                             <!-- Page Title-->
                             <?php
                             if ('on' === get_post_meta($post->ID, 'ca_custom_post_title_display', true)) {
@@ -50,15 +52,6 @@ if (file_exists(get_stylesheet_directory() . '/header.php')) {
                             print '<div class="entry-content">';
 
                             the_content();
-
-                            if (!$caweb_is_page_builder_used) {
-                                wp_link_pages(
-                                    array(
-                                        'before' => '<div class="page-links">' . esc_html__('Pages:', 'Divi'),
-                                        'after'  => '</div>',
-                                    )
-                                );
-                            }
 
                             print '</div>';
 

--- a/includes/templates/template-single.php
+++ b/includes/templates/template-single.php
@@ -17,13 +17,11 @@ if (file_exists(get_stylesheet_directory() . '/header.php')) {
 ?>
 
 <div id="page-container" class="page-container-ds">
-    
-    <?php
-        do_action("cagov_breadcrumb");
-    ?>
-
     <div id="main-content" class="main-content-ds single-column" tabindex="-1">
-        <div>
+        <?php
+            do_action("cagov_breadcrumb");
+        ?>
+        <div class="ds-content-layout">
             <main class="main-primary">
                 <div>
                     <?php
@@ -31,8 +29,12 @@ if (file_exists(get_stylesheet_directory() . '/header.php')) {
                         the_post();
                     ?>
 
+                    <?php
+                        $category = get_the_category();
+                    ?>
+
                         <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
-                            <category-label><?php the_category(); ?></category-label>
+                            <category-label><?php echo $category[0]->cat_name; ?></category-label>
                             <!-- Page Title-->
                             <?php
                             if ('on' === get_post_meta($post->ID, 'ca_custom_post_title_display', true)) {
@@ -51,15 +53,6 @@ if (file_exists(get_stylesheet_directory() . '/header.php')) {
 
                             the_content();
 
-                            if (!$caweb_is_page_builder_used) {
-                                wp_link_pages(
-                                    array(
-                                        'before' => '<div class="page-links">' . esc_html__('Pages:', 'Divi'),
-                                        'after'  => '</div>',
-                                    )
-                                );
-                            }
-
                             print '</div>';
 
                             ?>
@@ -70,12 +63,10 @@ if (file_exists(get_stylesheet_directory() . '/header.php')) {
                     <?php endwhile; ?>
                     <span class="return-top hidden-print"></span>
             </main>
-
         </div>
     </div>
+</div>
 
-</div>
-</div>
 
 <?php
     do_action("cagov_content_menu");

--- a/styles/page.css
+++ b/styles/page.css
@@ -60,45 +60,68 @@
 }
 
 .with-sidebar .main-content-default,
-.with-sidebar>* {
+.with-sidebar .ds-content-layout {
     display: flex;
     flex-wrap: wrap;
     margin: calc(var(--s1) / 2 * -1);
 }
 
-.with-sidebar.has-sidebar-left .main-content-default > *,
-.with-sidebar.has-sidebar-left .main-content-ds > .everylayout {
+.with-sidebar.has-sidebar-left .main-content-default>*,
+.with-sidebar.has-sidebar-left .main-content-ds .ds-content-layout>.everylayout {
     margin: calc(var(--s1) / 2);
     flex-basis: 267px;
     flex-grow: 1;
 }
 
-.with-sidebar.has-sidebar-left .main-content-default > :last-child,
-.with-sidebar.has-sidebar-left .main-content-ds > .everylayout:last-child {
+.with-sidebar.has-sidebar-left .main-content-default> :last-child,
+.with-sidebar.has-sidebar-left .main-content-ds .ds-content-layout>.everylayout:last-child {
     flex-basis: 0;
     flex-grow: 999;
     min-width: calc(50% - var(--s1));
 }
 
 .with-sidebar.has-sidebar-right .main-content-default,
-.with-sidebar.has-sidebar-right .main-content-ds  > .everylayout {
+.with-sidebar.has-sidebar-right .main-content-ds .ds-content-layout>.everylayout {
     flex-basis: 0;
     flex-grow: 999;
     min-width: calc(50% - var(--s1));
 }
 
-.with-sidebar.has-sidebar-right .main-content-default > * > :last-child,
-.with-sidebar.has-sidebar-right .main-content-ds > :last-child {
+.with-sidebar.has-sidebar-right .main-content-default>*> :last-child,
+.with-sidebar.has-sidebar-right .main-content-ds .ds-content-layout> :last-child {
     margin: calc(var(--s1) / 2);
     flex-basis: 267px;
     flex-grow: 1;
 }
 
+.with-sidebar.page-container-ds.has-sidebar-left main {
+    margin-left: 64px;
+    margin-right: 20px;
+}
+
+.with-sidebar.page-container-ds.has-sidebar-right main {
+    margin-right: 64px;
+    margin-left: 20px;
+}
+
 /* BREADCRUMB */
+
+.with-sidebar .main-container-ds {
+    max-width: 877px;
+}
+/* 
+.with-sidebar.page-container-default .breadcrumb {
+    margin-bottom: 0px;
+} */
+/* 
+.with-sidebar.page-container-ds .breadcrumb {
+    margin-bottom: 64px;
+} */
+
 .breadcrumb {
     display: block;
-    margin-top: 32px;
-    margin-bottom: 0px;
+    margin-top: 0px;
+    margin-bottom: 64px;
     background-color: #F9F9FA;
     padding: 8px 16px;
     font-size: 16px;
@@ -117,6 +140,10 @@
     padding-left: 5px;
     padding-right: 5px;
 }
+/* .page-container-default {
+    margin-top: 210px;
+    margin-bottom: -170px;
+} */
 
 /* Category label */
 .page-container-ds main category-label ul:not([class*="menu"]):not([class*="nav"]):not([class*="footer-links"]),
@@ -147,28 +174,6 @@ time {
 category-label a {
     color: #000;
     font-weight: 700;
-}
-
-.with-sidebar.page-container-default .breadcrumb {
-    margin-bottom: 0px;
-}
-
-.with-sidebar.page-container-ds .breadcrumb {
-    margin-bottom: 32px;
-}
-
-.with-sidebar.page-container-ds.has-sidebar-left main {
-    margin-left: 64px;
-    margin-right: 20px;
-}
-
-.with-sidebar.page-container-ds.has-sidebar-right main {
-    margin-right: 64px;
-    margin-left: 20px;
-}
-
-.with-sidebar .main-container-ds {
-    max-width: 877px;
 }
 
 /* CONTENT NAVIGATION */
@@ -328,46 +333,11 @@ main ul li {
 
 @media only screen and (max-width: 992px) {
 
-.with-sidebar .main-content-default, .with-sidebar>* {
-    display: block;
-}
+    .with-sidebar .main-content-default,
+    .with-sidebar .ds-content-layout {
+        display: block;
+    }
 
-/* 
-.with-sidebar .main-content-default,
-.with-sidebar>* {
-    display: flex;
-    flex-wrap: wrap;
-    margin: calc(var(--s1) / 2 * -1);
-}
-
-.with-sidebar.has-sidebar-left .main-content-default > *,
-.with-sidebar.has-sidebar-left>*>* {
-    margin: calc(var(--s1) / 2);
-    flex-basis: 267px;
-    flex-grow: 1;
-}
-
-.with-sidebar.has-sidebar-left .main-content-default > :last-child,
-.with-sidebar.has-sidebar-left>*> :last-child {
-    flex-basis: 0;
-    flex-grow: 999;
-    min-width: calc(50% - var(--s1));
-}
-
-.with-sidebar.has-sidebar-right .main-content-default,
-.with-sidebar.has-sidebar-right>*>* {
-    flex-basis: 0;
-    flex-grow: 999;
-    min-width: calc(50% - var(--s1));
-}
-
-.with-sidebar.has-sidebar-right .main-content-default > * > :last-child,
-.with-sidebar.has-sidebar-right>*> :last-child {
-    margin: calc(var(--s1) / 2);
-    flex-basis: 267px;
-    flex-grow: 1;
-} */
-    
 
     article {
         display: block;
@@ -498,6 +468,7 @@ main ul li {
 
 /* override card grid so they stack at theme breakpoint that slims main content */
 @media (max-width: 991px) {
+
     .cagov-grid,
     .cagov-grid .block-editor-block-list__layout {
         grid-template-columns: repeat(auto-fit, minmax(min(500px, 100%), 1fr));


### PR DESCRIPTION
* Accommodate main container wrapper needs for CAWeb interaction elements (shift our content into a div .ds-content-layout, which will be used for future design iterations as our Design System external div (preventing conflicts and div injections and changes from theme from slowing down iterations. (Note on implementing layouts like EveryLayout - working in a WordPress editing environment and creating editor parity with the output design benefits from having a reliable basis with minimal class conflicts.
* Merge link fix for Safari issue on hero links
* Temporary fix layout of breadcrumb on default Page type  (currently no pages use the default, but we are trying to make sure the default renders similarly to Page layout and can revisit more post-launch)
* Unlink category link from Post pages, we are not using category paths on the site with current design.