### PR TITLE
bump plugin number

### DIFF
--- a/ca-design-system-gutenberg-blocks.php
+++ b/ca-design-system-gutenberg-blocks.php
@@ -6,7 +6,7 @@
  * Description: Gutenberg blocks for CA Design System
  * Author: Office of Digital Innovation
  * Author URI: https://digital.ca.gov
- * Version: 1.0.10
+ * Version: 1.0.11
  * License: MIT
  * License URI: https://opensource.org/licenses/MIT
  * Text Domain: ca-design-system
@@ -22,7 +22,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Constants.
-define('CA_DESIGN_SYSTEM_GUTENBERG_BLOCKS__VERSION', '1.0.10');
+define('CA_DESIGN_SYSTEM_GUTENBERG_BLOCKS__VERSION', '1.0.11');
 define('CA_DESIGN_SYSTEM_GUTENBERG_BLOCKS__BLOCKS_DIR_PATH', plugin_dir_path(__FILE__));
 define('CA_DESIGN_SYSTEM_GUTENBERG_BLOCKS__ADMIN_URL', plugin_dir_url(__FILE__));
 define('CA_DESIGN_SYSTEM_GUTENBERG_BLOCKS__FILE', __FILE__);

--- a/includes/page-resources.php
+++ b/includes/page-resources.php
@@ -151,8 +151,8 @@ function cagov_content_menu()
     //     $image_height = $image_meta['height'];
     // }
     // <a href="/"><img src="$image_url" alt="echo $org_footer_logo_alt_text" /></a>
-?>
-    <div class="content-footer mb-3">
+    ?>
+    <div class="per-page-feedback-container">
         <cagov-feedback data-endpoint-url="https://fa-go-feedback-001.azurewebsites.net/sendfeedback"></cagov-feedback>
     </div>
     <div class="content-footer-container">
@@ -188,7 +188,7 @@ function cagov_content_menu()
             </div>
         </div>
     </div>
-<?php
+    <?php
 }
 
 /**

--- a/styles/page.css
+++ b/styles/page.css
@@ -69,6 +69,85 @@
     margin-left: 20px;
 }
 
+
+/* For custom css -- conflicts are back, these overrides set them right, but need to be re-integrated with main markup. */
+
+/* Fixing all block spacing */
+
+.page-container-ds {
+    margin: 0 auto;
+}
+
+.single-column {
+    margin: 0 auto;
+}
+
+/* First Block has a top margin */
+#main-content {
+    margin-top: 0px; /* Navigation has extra 32px */
+    margin-bottom: 32px;
+}
+
+.cagov-block {
+    margin-bottom: 64px;
+}
+
+/* Reset wp block columns spacing */
+.wp-block-columns {
+    margin-top: 0px;
+    margin-bottom: 0 !important; /* Conflict with WP styles & load order */
+}
+
+.wp-block-column {
+    margin-top: 0px;
+    margin-bottom: 0px;
+}
+
+.wp-block-column .cagov-block {
+    margin-bottom: 64px;
+}
+
+@media (min-width: 992px) {
+    #main-content.main-content-ds.landing .breadcrumb {
+        margin-top: 0px;
+        margin-bottom: 64px !important; /* conflict with divi breadcrumb class*/
+        padding-top: 0px !important;
+        padding-bottom: 0px !important;
+    }
+
+    #main-content.main-content-ds.single-column .breadcrumb,
+    .with-sidebar.has-sidebar-left.page-container-ds #main-content.main-content-ds .breadcrumb {
+        margin-top: 32px;
+        margin-bottom: 64px !important;  /* conflict with divi breadcrumb class*/
+        padding-top: 0px !important;
+        padding-bottom: 0px !important;
+    }
+}
+
+.cagov-block h2,
+.cagov-block h3,
+.cagov-block h4,
+.cagov-block h6,
+.cagov-block h6 {
+    margin-bottom: 24px;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+    padding-bottom: 0 !important;
+}
+
+.wp-block-column h2 {
+    margin-top: 0;
+}
+
+
+
+
 /* BREADCRUMB */
 
 .with-sidebar .main-container-ds {
@@ -245,7 +324,6 @@ cagov-content-navigation a {
 
 /* Gutenberg Block alignment */
 
-
 /* TYPOGRAPHY */
 h1.page-title {
     margin: 0 0 0 0;
@@ -287,6 +365,18 @@ main ul li {
 
     article {
         display: block;
+    }
+
+
+    /* First Block has a top margin */
+
+
+    .cagov-block {
+        margin-bottom: 48px;
+    }
+
+    .wp-block-column .cagov-block {
+        margin-bottom: 48px;
     }
 
     /* BREADCRUMB */
@@ -645,8 +735,6 @@ ol.steps li:last-child {
     border: 1px solid #ededef !important;
 }
 
-/* TEMPORARY WORKING OVERRIDES, if any */
-
 .return-top:after {
     padding-right: 4px;
 }
@@ -678,114 +766,3 @@ article a {
     text-underline-position: under;
 }
 
-/* For custom css -- conflicts are back, these overrides set them right, but need to be re-integrated with main markup. */
-
-/* Fixing all block spacing */
-
-.page-container-ds {
-    margin: 0 auto;
-}
-
-.single-column {
-    margin: 0 auto;
-}
-
-/* First Block has a top margin */
-#main-content {
-    margin-top: 0px; /* Navigation has extra 32px */
-    margin-bottom: 32px;
-}
-
-.main-content-ds {
-    /* margin-bottom: 64px; */
-}
-
-#main-content.single-column.landing {
-    /* margin-top: 0px; */
-}
-
-#main-content.single-column.landing .cagov-block {
-    /* margin-top: 0px;
-    margin-bottom: 64px; */
-}
-
-.cagov-block {
-    margin-bottom: 64px;
-}
-
-/* Reset wp block columns spacing */
-.wp-block-columns {
-    margin-top: 0px;
-    margin-bottom: 0 !important; /* Conflict with WP styles & load order */
-}
-
-.wp-block-column {
-    margin-top: 0px;
-    margin-bottom: 0px;
-}
-
-.wp-block-column .cagov-block {
-    margin-bottom: 64px;
-}
-
-@media (min-width: 992px) {
-    #main-content.main-content-ds.landing .breadcrumb {
-        margin-top: 0px;
-        margin-bottom: 64px !important; /* conflict with divi breadcrumb class*/
-        padding-top: 0px !important;
-        padding-bottom: 0px !important;
-    }
-
-    #main-content.main-content-ds.single-column .breadcrumb,
-    .with-sidebar.has-sidebar-left.page-container-ds #main-content.main-content-ds .breadcrumb {
-        margin-top: 32px;
-        margin-bottom: 64px !important;  /* conflict with divi breadcrumb class*/
-        padding-top: 0px !important;
-        padding-bottom: 0px !important;
-    }
-}
-
-.cagov-block h2,
-.cagov-block h3,
-.cagov-block h4,
-.cagov-block h6,
-.cagov-block h6 {
-    margin-bottom: 24px;
-}
-
-/* .cagov-stack h1,
-.cagov-stack h2,
-.cagov-stack h3,
-.cagov-stack h4,
-.cagov-card h1,
-.cagov-card h2,
-.cagov-card h3,
-.cagov-card h4 {
-    margin: 0;
-} */
-
-
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
-    padding-bottom: 0 !important;
-}
-
-.cagov-stack h1,
-.cagov-stack h2,
-.cagov-stack h3,
-.cagov-stack h4,
-.cagov-card h1,
-.cagov-card h2,
-.cagov-card h3,
-.cagov-card h4 {
-    /* margin-top: 64px;
-    margin-bottom: 24px; */
-}
-
-.wp-block-column h2 {
-    margin-top: 0;
-}

--- a/styles/page.css
+++ b/styles/page.css
@@ -164,8 +164,6 @@ cagov-content-navigation a {
 
 /* CONTENT FOOTER */
 
-.per-page-feedback-container {}
-
 .content-footer-container {
     border-bottom: 1px solid #EDEDEF;
     border-top: 1px solid #EDEDEF;
@@ -173,12 +171,17 @@ cagov-content-navigation a {
     padding-bottom: 23px;
 }
 
+.per-page-feedback-container {
+    max-width: 1176px !important;
+    margin-right: auto;
+    margin-left: auto;
+    margin-bottom: 32px;
+}
+
 .content-footer {
     max-width: 1176px !important;
     margin-right: auto;
     margin-left: auto;
-    /* padding-left: 15px;
-    padding-right: 15px; */
     display: flex;
     flex-direction: row;
     justify-content: flex-start;
@@ -192,6 +195,10 @@ cagov-content-navigation a {
 
 .menu-section {
     margin-right: 24px;
+}
+
+.menu-section:last-child {
+    margin-right: 0px;
 }
 
 .menu-section ul,
@@ -382,11 +389,23 @@ main ul li {
     }
 
     /* Content Menu */
+
+    .per-page-feedback-container {
+        padding-left: 15px;
+        padding-right: 15px;
+    }
+
+    .content-footer-container {
+        padding-left: 15px;
+        padding-right: 15px;
+    }
+    
     .content-footer {
         display: flex;
         flex-direction: column;
         justify-content: flex-start;
         align-items: flex-start;
+        margin-bottom: 32px;
     }
 
     .content-footer .logo-small {
@@ -627,10 +646,6 @@ ol.steps li:last-child {
 }
 
 /* TEMPORARY WORKING OVERRIDES, if any */
-
-.return-top {
-    margin-right: 10px;
-}
 
 .return-top:after {
     padding-right: 4px;


### PR DESCRIPTION
* Responsive style and layout adjustments
* Performance improvements to plugin
* Accessibility on hero (requires resaving hero element)
* Name spacing fixes across all blocks
* Control pagination on announcmenets
* Remove extra header elements for content navigation
* Rename interface template names to be more clear
* Fix broken event pattern block (bad namespace)

DB update note: Post list, card grid & hero need minor css adjustment on update to match correct namespace & add new .cagov-block which controls spacing between elements. .cagov-stack aligns elements with in a block. These can be manual fixes and do not require any migration scripts at this point in time.