### PR TITLE
Add comments and simplify mime-type request

### DIFF
--- a/ca-design-system-gutenberg-blocks.php
+++ b/ca-design-system-gutenberg-blocks.php
@@ -71,6 +71,7 @@ require_once CAGOV_DESIGN_SYSTEM_HEADLESS_WORDPRESS__DIR_PATH . '/includes/publi
 require_once CAGOV_DESIGN_SYSTEM_HEADLESS_WORDPRESS__DIR_PATH . '/includes/publishing/api_preview.php';
 require_once CAGOV_DESIGN_SYSTEM_HEADLESS_WORDPRESS__DIR_PATH . '/includes/publishing/preview_button.php';
 require_once CAGOV_DESIGN_SYSTEM_HEADLESS_WORDPRESS__DIR_PATH . '/includes/publishing/site_options.php';
+require_once CAGOV_DESIGN_SYSTEM_HEADLESS_WORDPRESS__DIR_PATH . '/includes/publishing/headless_mime_types.php';
 
 /* Include Gutenberg blocks and patterns. */
 // Core design system blocks (periodically synced with design system changes)

--- a/includes/publishing/headless_mime_types.php
+++ b/includes/publishing/headless_mime_types.php
@@ -1,0 +1,16 @@
+<?php
+
+// Allow users who can upload files to include SVG, CSV and JSON files.
+// This allows us to provide files that can be used in custom data visualizations.
+function cagov_gb_enable_headless_asset_upload($upload_mimes)
+{
+    if (current_user_can('upload_files')) {
+        $upload_mimes['svg'] = 'image/svg+xml'; // SVG files must be prefixed with xml tag
+        $upload_mimes['csv'] = 'text/csv';
+        $upload_mimes['json'] = 'text/plain';
+    }
+
+    return $upload_mimes;
+}
+
+add_filter('upload_mimes', 'cagov_gb_enable_headless_asset_upload', 10, 1);


### PR DESCRIPTION
Add support for SVG, CSV, JSON mime-types.
(Note, the "headless publishing" features will be moving to a separate plugin as we start to upgrade this plugin for just gutenberg blocks, but keeping this release very simple until we are ready with the new plugins.)