### PR TITLE
Release/1.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+### 1.1.8
+January 25, 2024
+- Change the logic for how non-CAWeb, Design System page templates are applied. An `apply_filters` hook `ca_design_system_gutenberg_blocks_include_page_templates` can be set to `true` to include some page templates for backwards compatibility on some CA Design System WordPress sites with CA Design System layouts.
+
 ### 1.1.7
 August 11, 2022
 - Added references to partial header file to be compatible with CAWeb ^1.6.3.

--- a/ca-design-system-gutenberg-blocks.php
+++ b/ca-design-system-gutenberg-blocks.php
@@ -97,7 +97,7 @@ if ( 'CAWeb' == $theme->name) {
 	include_once CAGOV_DESIGN_SYSTEM_HEADLESS_WORDPRESS__DIR_PATH . '/includes/caweb-page-resources.php';
 	include_once CAGOV_DESIGN_SYSTEM_HEADLESS_WORDPRESS__DIR_PATH . '/includes/caweb-filters.php';
 	include_once CAGOV_DESIGN_SYSTEM_HEADLESS_WORDPRESS__DIR_PATH . '/includes/caweb-functions.php';
-} elseif ( isset($_ENV['PANTHEON_ENVIRONMENT'])) || apply_filters( 'cagov_gb_is_pantheon', true ) ) {
+} elseif ( isset($_ENV['PANTHEON_ENVIRONMENT']) || apply_filters( 'cagov_gb_is_pantheon', true ) ) {
 	// @NOTE: if there is a third theme option or version number of the theme, we can handle that around here.
 	// Add page templates for "Pantheon version" of theme (currently: @cagov/cagov-wp-theme-generate-press)
 	if (!class_exists('CADesignSystemGutenbergBlocks_Plugin_Templates_Loader_Pantheon')) {

--- a/ca-design-system-gutenberg-blocks.php
+++ b/ca-design-system-gutenberg-blocks.php
@@ -22,7 +22,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Plugin Constants.
-define('CAGOV_DESIGN_SYSTEM_HEADLESS_WORDPRESS__VERSION', '1.1.7');
+define('CAGOV_DESIGN_SYSTEM_HEADLESS_WORDPRESS__VERSION', '1.1.8');
 define('CAGOV_DESIGN_SYSTEM_HEADLESS_WORDPRESS__DIR_PATH', plugin_dir_path(__FILE__));
 define('CAGOV_DESIGN_SYSTEM_HEADLESS_WORDPRESS__ADMIN_URL', plugin_dir_url(__FILE__));
 define('CAGOV_DESIGN_SYSTEM_HEADLESS_WORDPRESS__FILE', __FILE__);
@@ -97,14 +97,16 @@ if ( 'CAWeb' == $theme->name) {
 	include_once CAGOV_DESIGN_SYSTEM_HEADLESS_WORDPRESS__DIR_PATH . '/includes/caweb-page-resources.php';
 	include_once CAGOV_DESIGN_SYSTEM_HEADLESS_WORDPRESS__DIR_PATH . '/includes/caweb-filters.php';
 	include_once CAGOV_DESIGN_SYSTEM_HEADLESS_WORDPRESS__DIR_PATH . '/includes/caweb-functions.php';
-} elseif ( isset($_ENV['PANTHEON_ENVIRONMENT']) || apply_filters( 'cagov_gb_is_pantheon', true ) ) {
-	// @NOTE: if there is a third theme option or version number of the theme, we can handle that around here.
-	// Add page templates for "Pantheon version" of theme (currently: @cagov/cagov-wp-theme-generate-press)
-	if (!class_exists('CADesignSystemGutenbergBlocks_Plugin_Templates_Loader_Pantheon')) {
-		include_once CAGOV_DESIGN_SYSTEM_HEADLESS_WORDPRESS__DIR_PATH . '/includes/class-ca-design-system-gutenberg-blocks-templates-pantheon.php';
-	}
+} else {
+ 	if (apply_filters( 'ca_design_system_gutenberg_blocks_include_page_templates', true ) ) {
+		// @NOTE: if there is a third theme option or version number of the theme, we can handle that around here.
+		// Add page templates for "Pantheon version" of theme (currently: @cagov/cagov-wp-theme-generate-press)
+		if (!class_exists('CADesignSystemGutenbergBlocks_Plugin_Templates_Loader_Pantheon')) {
+			include_once CAGOV_DESIGN_SYSTEM_HEADLESS_WORDPRESS__DIR_PATH . '/includes/class-ca-design-system-gutenberg-blocks-templates-pantheon.php';
+		}
 
-	CADesignSystemGutenbergBlocks_Plugin_Templates_Loader_Pantheon::get_instance();
-	include_once CAGOV_DESIGN_SYSTEM_HEADLESS_WORDPRESS__DIR_PATH . '/includes/pantheon-filters.php';
-	include_once CAGOV_DESIGN_SYSTEM_HEADLESS_WORDPRESS__DIR_PATH . '/includes/pantheon-functions.php';
+		CADesignSystemGutenbergBlocks_Plugin_Templates_Loader_Pantheon::get_instance();
+		include_once CAGOV_DESIGN_SYSTEM_HEADLESS_WORDPRESS__DIR_PATH . '/includes/pantheon-filters.php';
+		include_once CAGOV_DESIGN_SYSTEM_HEADLESS_WORDPRESS__DIR_PATH . '/includes/pantheon-functions.php';
+	}
 }

--- a/ca-design-system-gutenberg-blocks.php
+++ b/ca-design-system-gutenberg-blocks.php
@@ -97,7 +97,7 @@ if ( 'CAWeb' == $theme->name) {
 	include_once CAGOV_DESIGN_SYSTEM_HEADLESS_WORDPRESS__DIR_PATH . '/includes/caweb-page-resources.php';
 	include_once CAGOV_DESIGN_SYSTEM_HEADLESS_WORDPRESS__DIR_PATH . '/includes/caweb-filters.php';
 	include_once CAGOV_DESIGN_SYSTEM_HEADLESS_WORDPRESS__DIR_PATH . '/includes/caweb-functions.php';
-} elseif ( apply_filters( 'cagov_gb_is_pantheon', true ) ) {
+} elseif ( isset($_ENV['PANTHEON_ENVIRONMENT'])) || apply_filters( 'cagov_gb_is_pantheon', true ) ) {
 	// @NOTE: if there is a third theme option or version number of the theme, we can handle that around here.
 	// Add page templates for "Pantheon version" of theme (currently: @cagov/cagov-wp-theme-generate-press)
 	if (!class_exists('CADesignSystemGutenbergBlocks_Plugin_Templates_Loader_Pantheon')) {

--- a/ca-design-system-gutenberg-blocks.php
+++ b/ca-design-system-gutenberg-blocks.php
@@ -97,7 +97,7 @@ if ( 'CAWeb' == $theme->name) {
 	include_once CAGOV_DESIGN_SYSTEM_HEADLESS_WORDPRESS__DIR_PATH . '/includes/caweb-page-resources.php';
 	include_once CAGOV_DESIGN_SYSTEM_HEADLESS_WORDPRESS__DIR_PATH . '/includes/caweb-filters.php';
 	include_once CAGOV_DESIGN_SYSTEM_HEADLESS_WORDPRESS__DIR_PATH . '/includes/caweb-functions.php';
-} else {
+} elseif ( apply_filters( 'cagov_gb_is_pantheon', true ) ) {
 	// @NOTE: if there is a third theme option or version number of the theme, we can handle that around here.
 	// Add page templates for "Pantheon version" of theme (currently: @cagov/cagov-wp-theme-generate-press)
 	if (!class_exists('CADesignSystemGutenbergBlocks_Plugin_Templates_Loader_Pantheon')) {


### PR DESCRIPTION
This deprecated plugin is still in use on some ca.gov websites, and the changes in this release include:

* a check for an `apply_filters` hook to suppress Pantheon specific code
* checking to see if the Pantheon environment variable is set.

